### PR TITLE
fix missing error import

### DIFF
--- a/dtls/sslconnection.py
+++ b/dtls/sslconnection.py
@@ -54,6 +54,7 @@ from err import SSL_ERROR_WANT_READ, SSL_ERROR_SYSCALL
 from err import ERR_COOKIE_MISMATCH, ERR_NO_CERTS
 from err import ERR_NO_CIPHER, ERR_HANDSHAKE_TIMEOUT, ERR_PORT_UNREACHABLE
 from err import ERR_READ_TIMEOUT, ERR_WRITE_TIMEOUT
+from err import ERR_BOTH_KEY_CERT_FILES_SVR
 from x509 import _X509, decode_cert
 from tlock import tlock_init
 from openssl import *


### PR DESCRIPTION
When a listening socket doesn't specify a cert and key correctly, the error code that is to be issued isn't imported from err.py.  This patch adds that import.
