### PR TITLE
MacOS X library-path detection

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -76,6 +76,13 @@ used by CPython 2.7. Installation of Microsoft redistributable runtime
 packages should therefore not be required on machines with CPython
 2.7. The version of OpenSSL distributed with PyDTLS 0.1.0 is 1.0.1c.
 
+For MacOS X, the OpenSSL comes built in, but it's too old. To use PyDTLS, it's
+necessary to build and install a newer OpenSSL version.  Since Mac's can be
+fairly sensitive to how OpenSSL is updated, systems like HomeBrew and MacPorts
+provide an environment that will more simply build it for you.  If you use
+either of these, PyDTLS will look in their default install locations for
+updated libraries.
+
 The OpenSSL version used by PyDTLS can be determined from the values
 of *sslconnection's* DTLS_OPENSSL_VERSION_NUMBER,
 DTLS_OPENSSL_VERSION, and DTLS_OPENSSL_VERSION_INFO. These variables

--- a/dtls/openssl.py
+++ b/dtls/openssl.py
@@ -73,6 +73,21 @@ if sys.platform.startswith('win'):
         # If these don't exist, then let the exception propagate
         libcrypto = CDLL(release_cryptodll_path)
         libssl = CDLL(release_ssldll_path)
+elif sys.platform == 'darwin':
+    # MacOS X does not supply a new enough libssl
+    # look for HomeBrew or MacPorts
+    HOMEBREW_LIBS='/usr/local/opt/openssl/lib/'
+    MACPORTS_LIBS='/opt/local/lib'
+    if path.exists(HOMEBREW_LIBS):
+        libcrypto = CDLL(path.join(HOMEBREW_LIBS, 'libcrypto.1.0.0.dylib'))
+        libssl = CDLL(path.join(HOMEBREW_LIBS, 'libssl.1.0.0.dylib'))
+    elif path.exists(MACPORTS_LIBS):
+        libcrypto = CDLL(path.join(MACPORTS_LIBS, 'libcrypto.1.0.0.dylib'))
+        libssl = CDLL(path.join(MACPORTS_LIBS, 'libssl.1.0.0.dylib'))
+    else:
+        # try to find it in the normal link path
+        libcrypto = CDLL("libcrypto.1.0.0.dylib")
+        libssl = CDLL("libssl.1.0.0.dylib")
 else:
     libcrypto = CDLL("libcrypto.so.1.0.0")
     libssl = CDLL("libssl.so.1.0.0")


### PR DESCRIPTION
Add support for installing on MacOS X.  This is complicated a bit because even the newest MacOS doesn't provide a new enough libssl (i.e. only 0.9.8, not 1.0.0).  It's also a bit complicated to compile your own from scratch, because MacOS doesn't take kindly to installing a newer libssl.  Rather than fight with this, it's most common to use MacPorts or HomeBrew to install libssl, with the caveat that you have to know where to look for it.

This patch adds support to look in the normal places for HomeBrew and MacPorts, before defaulting to some system version.  It also updates the README.txt to mention why it doesn't use the built-in OpenSSL and to give a vague hint at how to get one that works.
